### PR TITLE
Exclude special characters for plate number

### DIFF
--- a/app/src/main/java/com/cpen391/userapp/dashboardFragments/car/addPlateFragment.java
+++ b/app/src/main/java/com/cpen391/userapp/dashboardFragments/car/addPlateFragment.java
@@ -26,6 +26,7 @@ import com.cpen391.userapp.RetrofitInterface;
 import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.regex.Pattern;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -80,12 +81,20 @@ public class addPlateFragment extends Fragment {
             @Override
             public void onClick(View view) {
                 Constants.closeKeyboard(getActivity());
-                retrofit = new Retrofit.Builder()
-                        .baseUrl(Constants.BASE_URL)
-                        .addConverterFactory(GsonConverterFactory.create())
-                        .build();
-                retrofitInterface = retrofit.create(RetrofitInterface.class);
-                postCar();
+                Pattern p = Pattern.compile("[^A-Z0-9 ]");
+
+                /* check if entered plate number is valid */
+                if(p.matcher(plateNo.getText().toString()).find()){
+                    Toast.makeText(getContext(), "Invalid Entry: Please enter a valid plate number with only letters and spaces.", Toast.LENGTH_SHORT).show();
+                } else {
+                    /* submit the plate */
+                    retrofit = new Retrofit.Builder()
+                            .baseUrl(Constants.BASE_URL)
+                            .addConverterFactory(GsonConverterFactory.create())
+                            .build();
+                    retrofitInterface = retrofit.create(RetrofitInterface.class);
+                    postCar();
+                }
             }
         });
     }

--- a/app/src/main/res/layout/fragment_add_plate.xml
+++ b/app/src/main/res/layout/fragment_add_plate.xml
@@ -64,7 +64,7 @@
             android:layout_margin="8dp"
             android:layout_weight="1"
             android:hint="@string/plate_example"
-            android:inputType="text" />
+            android:inputType="textCapCharacters" />
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

Limit license plate input to only allow Uppercase letters, digits, and space

## :hammer: Validation Strategy

Verify that adding a plate number with `ABC 12` works while `ABC @2`  returns an error message

